### PR TITLE
[Fix] changed device table and procedure

### DIFF
--- a/migrations.sqls/20231202191053-create-tables.up.sql
+++ b/migrations.sqls/20231202191053-create-tables.up.sql
@@ -16,7 +16,7 @@ CREATE TABLE `devices` (
     `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `user_id` INT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE INDEX `device_serial_user_id_unique` (`serial` ASC, `user_id` ASC) VISIBLE,
+    UNIQUE INDEX `device_serial_user_id_unique` (`serial` ASC, `user_id` ASC, `type` ASC) VISIBLE,
     INDEX `device_user_id_fk_idx` USING BTREE (`user_id`) VISIBLE,
     CONSTRAINT `user_id_fk`
     FOREIGN KEY (`user_id`)

--- a/migrations.sqls/20231212223020-create-procedure-login-user.up.sql
+++ b/migrations.sqls/20231212223020-create-procedure-login-user.up.sql
@@ -50,7 +50,7 @@ BEGIN
     FROM 
         `devices` 
     WHERE 
-        `serial` = `_device_serial` AND `user_id` = `_test_user_id`;
+        `serial` = `_device_serial` AND `user_id` = `_test_user_id` AND `type` = `_device_type`;
         
     IF `_found_device_id` IS NULL THEN
         INSERT INTO


### PR DESCRIPTION
Close #54 

##  Changes
- [x] Changed the table to accept a user ID device type and serial, as composite key.
- [x] Changed the login procedure to find by the composite key and save if the composite key don't exists.